### PR TITLE
🧹 [code health improvement] Use specific type instead of 'any' for error catch in JoinPartyForm.tsx

### DIFF
--- a/src/components/JoinPartyForm.tsx
+++ b/src/components/JoinPartyForm.tsx
@@ -54,9 +54,10 @@ export function JoinPartyForm() {
       toast({ title: "Joined party!", description: `Waiting for host to start.` })
       router.push(`/lobby/${upperCode}`)
 
-    } catch (error: any) {
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "An unknown error occurred"
       console.error(error)
-      toast({ title: "Error joining party", description: error.message, variant: "destructive" })
+      toast({ title: "Error joining party", description: errorMessage, variant: "destructive" })
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
🎯 **What:** Removed the explicit `any` type from the `catch` block in `src/components/JoinPartyForm.tsx`.
💡 **Why:** It's a standard and safer TypeScript pattern to type catch block errors as `unknown` and narrow the type before using (e.g. checking `error instanceof Error`) rather than relying on `any`.
✅ **Verification:** Ran `npm run lint` and `npm run build` locally with no regressions.
✨ **Result:** Improved type safety and maintainability by properly handling unexpected error types in the `handleJoin` function.

---
*PR created automatically by Jules for task [6353585645774521471](https://jules.google.com/task/6353585645774521471) started by @beenycool*